### PR TITLE
@unlink and custom error handlers

### DIFF
--- a/xlsxwriter.class.php
+++ b/xlsxwriter.class.php
@@ -9,7 +9,7 @@ class XLSXWriter
 {
 	//------------------------------------------------------------------
 	//http://office.microsoft.com/en-us/excel-help/excel-specifications-and-limits-HP010073849.aspx
-	const EXCEL_2007_MAX_ROW=1048576; 
+	const EXCEL_2007_MAX_ROW=1048576;
 	const EXCEL_2007_MAX_COL=16384;
 	//------------------------------------------------------------------
 	protected $author ='Doc Author';
@@ -68,11 +68,18 @@ class XLSXWriter
 			self::finalizeSheet($sheet_name);//making sure all footers have been written
 		}
 
-		@unlink($filename);//if the zip already exists, overwrite it
+        if ( file_exists( $filename ) ) {
+            if ( is_writable( $filename ) ) {
+                @unlink( $filename ); //if the zip already exists, remove it
+            } else {
+                self::log( "Error in " . __CLASS__ . "::" . __FUNCTION__ . ", file is not writeable." );
+                return;
+            }
+        }
 		$zip = new ZipArchive();
 		if (empty($this->sheets))                       { self::log("Error in ".__CLASS__."::".__FUNCTION__.", no worksheets defined."); return; }
 		if (!$zip->open($filename, ZipArchive::CREATE)) { self::log("Error in ".__CLASS__."::".__FUNCTION__.", unable to create zip."); return; }
-		
+
 		$zip->addEmptyDir("docProps/");
 		$zip->addFromString("docProps/app.xml" , self::buildAppXML() );
 		$zip->addFromString("docProps/core.xml", self::buildCoreXML());
@@ -105,8 +112,8 @@ class XLSXWriter
 		$sheet_filename = $this->tempFilename();
 		$sheet_xmlname = 'sheet' . (count($this->sheets) + 1).".xml";
 		$this->sheets[$sheet_name] = (object)array(
-			'filename' => $sheet_filename, 
-			'sheetname' => $sheet_name, 
+			'filename' => $sheet_filename,
+			'sheetname' => $sheet_name,
 			'xmlname' => $sheet_xmlname,
 			'row_count' => 0,
 			'file_writer' => new XLSXWriter_BuffererWriter($sheet_filename),
@@ -176,7 +183,7 @@ class XLSXWriter
 		$sheet->row_count++;
 		$this->current_sheet = $sheet_name;
 	}
-	
+
 	protected function finalizeSheet($sheet_name)
 	{
 		if (empty($sheet_name) || $this->sheets[$sheet_name]->finalized)
@@ -332,7 +339,7 @@ class XLSXWriter
 		}
 		$file->write('</sst>');
 		$file->close();
-		
+
 		return $temporary_filename;
 	}
 
@@ -487,7 +494,7 @@ class XLSXWriter
 		}
 
 		//using 1900 as epoch, not 1904, ignoring 1904 special case
-		
+
 		# Special cases for Excel.
 		if ("$year-$month-$day"=='1899-12-31')  return $seconds      ;    # Excel 1900 epoch
 		if ("$year-$month-$day"=='1900-01-00')  return $seconds      ;    # Excel 1900 epoch
@@ -572,11 +579,11 @@ class XLSXWriter_BuffererWriter
 		}
 	}
 
-	public function __destruct() 
+	public function __destruct()
 	{
 		$this->close();
 	}
-	
+
 	public function ftell()
 	{
 		if ($this->fd) {

--- a/xlsxwriter.class.php
+++ b/xlsxwriter.class.php
@@ -68,14 +68,14 @@ class XLSXWriter
 			self::finalizeSheet($sheet_name);//making sure all footers have been written
 		}
 
-        if ( file_exists( $filename ) ) {
-            if ( is_writable( $filename ) ) {
-                @unlink( $filename ); //if the zip already exists, remove it
-            } else {
-                self::log( "Error in " . __CLASS__ . "::" . __FUNCTION__ . ", file is not writeable." );
-                return;
-            }
-        }
+		if ( file_exists( $filename ) ) {
+			if ( is_writable( $filename ) ) {
+				@unlink( $filename ); //if the zip already exists, remove it
+			} else {
+				self::log( "Error in " . __CLASS__ . "::" . __FUNCTION__ . ", file is not writeable." );
+				return;
+			}
+		}
 		$zip = new ZipArchive();
 		if (empty($this->sheets))                       { self::log("Error in ".__CLASS__."::".__FUNCTION__.", no worksheets defined."); return; }
 		if (!$zip->open($filename, ZipArchive::CREATE)) { self::log("Error in ".__CLASS__."::".__FUNCTION__.", unable to create zip."); return; }


### PR DESCRIPTION
When using custom error handlers, php triggers error handler when using supression mark "@".
Because of that, writeToFile function creates a warning error.
This patch checks for existing file before unlink