### PR TITLE
Fixed issue: Ctrl character in value strings break the final document

### DIFF
--- a/xlsxwriter.class.php
+++ b/xlsxwriter.class.php
@@ -43,12 +43,12 @@ class XLSXWriter
 			}
 		}
 	}
-	
+
 	public function setTempDir($dir)
 	{
 		$this->temp_dir = $dir;
 	}
-	
+
 	protected function tempFilename()
 	{
 		$temp_dir = is_null($this->temp_dir) ? sys_get_temp_dir() : $this->temp_dir;
@@ -301,7 +301,7 @@ class XLSXWriter
 		$sheet->file_writer->close();
 		$sheet->finalized=true;
 	}
-	
+
 	public function markMergedCell($sheet_name, $start_cell_row, $start_cell_column, $end_cell_row, $end_cell_column)
 	{
 		if (empty($sheet_name) || $this->sheets[$sheet_name]->finalized)
@@ -582,6 +582,7 @@ class XLSXWriter
 	//------------------------------------------------------------------
 	public static function xmlspecialchars($val)
 	{
+        $val=preg_replace('/[\x00-\x08\x0B\x0C\x0E-\x1F\x80-\x9F]/u', '', $val);
 		return str_replace("'", "&#39;", htmlspecialchars($val));
 	}
 	//------------------------------------------------------------------


### PR DESCRIPTION
This little patch prevents the problem that any (UTF-8 or not)  control character may break the XLSX file. Excel usually complains about the file being broken and is not able to repair it.
While you can argue that this should not be in the value text in general I think that control characters serve no purpose at all in an Excel sheet.

The patch strips all control characters that are not CR, LF or TAB before writing the value to the XML file.
