### PR TITLE
Avoid forcing all projects to download xrstf/composer-php52

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -10,10 +10,10 @@
         "classmap": ["xlsxwriter.class.php"]
     },
     "require-dev": {
+        "xrstf/composer-php52": "1.*",
         "phpunit/phpunit": "4.3.*"
     },
     "require": {
-        "xrstf/composer-php52": "1.*",
         "php": ">=5.2.1"
     },
     "scripts": {


### PR DESCRIPTION
Using PHP 5.2 should be quite rare now (and even more combined with composer).
Thus, using xrstf/composer-php52 requires the root package to define some scripts, so they probably depend on the package explicitly already when wanting to use it.
Moving xrstf/composer-php52 to a dev requirement avoid forcing all projects to install it when they run on newer PHP versions.