### PR TITLE
Adding ability to set column widths for all columns or for columns in a certain sheet

### DIFF
--- a/README.md
+++ b/README.md
@@ -94,4 +94,12 @@ Basic cell styles have been available since version 0.30
 | halign     | general, left, right, justify, center |
 | valign     | bottom, center, distributed |
 
+Set column width the same for all columns or set colwidths by column for each sheet since version 0.XX
+ -- see example-colwidths.php
+ Two new members of the class that must be called before sheet is initialized:
+	$writer->setColWidth("40"); -- sets all columns for newly initialized sheets to 40
+	$writer->setColWidths('Sheet1', array(7,12,15,40)); -- sets for four columns in Sheet1 to specific widths
+
+
+
 

--- a/example-colwidths.php
+++ b/example-colwidths.php
@@ -1,5 +1,5 @@
 <?php
-		include_once('PAI_xlsxwriter.class.php');
+		include_once('xlsxwriter.class.php');
 		$filename = "example-colwidths.xlsx";
 		header('Content-disposition: attachment; filename="'.XLSXWriter::sanitize_filename($filename).'"');
 		header('Content-Type: application/vnd.openxmlformats-officedocument.spreadsheetml.sheet');

--- a/example-colwidths.php
+++ b/example-colwidths.php
@@ -1,0 +1,38 @@
+<?php
+		include_once('PAI_xlsxwriter.class.php');
+		$filename = "example-colwidths.xlsx";
+		header('Content-disposition: attachment; filename="'.XLSXWriter::sanitize_filename($filename).'"');
+		header('Content-Type: application/vnd.openxmlformats-officedocument.spreadsheetml.sheet');
+		header('Content-Transfer-Encoding: binary');
+		header('Cache-Control: must-revalidate');
+		header('Pragma: public');
+		
+		//setup heading row style
+		$hstyle = array( 'font'=>'Arial','font-size'=>10,'font-style'=>'bold', 'halign'=>'center', 'border'=>'bottom');
+		$hdr = array('Level'=>'string', 'Function'=>'string','ID'=>'string','Message'=>'string');
+		
+		//setup data array
+		$db[]=array("1","test1","203","test function working");
+		$db[]=array("2","test2","204","test function failing");
+		
+		//write header then sheet data and output file
+		$writer = new XLSXWriter();
+		
+		//write sheet with standard widths
+		$writer->writeSheetRow('Ex1',array_keys($hdr),$hstyle);
+		$writer->writeSheet($db,'Ex1',$hdr,true);
+		
+		//set column width for all columns in a sheet and write sheet
+		$writer->setColWidth("40");
+		$writer->writeSheetRow('Ex2',array_keys($hdr),$hstyle);
+		$writer->writeSheet($db,'Ex2',$hdr,true);
+		
+		//set array of column widths and write sheet
+		$writer->setColWidths('Ex3',array(7,12,15,40));
+		$writer->writeSheetRow('Ex3',array_keys($hdr),$hstyle);
+		$writer->writeSheet($db,'Ex3',$hdr,true);
+		
+		// write file
+		$writer->writeToStdOut();
+		unset($writer);
+?>

--- a/example-colwidths.php
+++ b/example-colwidths.php
@@ -1,5 +1,8 @@
 <?php
 		include_once('xlsxwriter.class.php');
+		ini_set('display_errors', 0);
+		ini_set('log_errors', 1);
+		error_reporting(E_ALL & ~E_NOTICE);
 		$filename = "example-colwidths.xlsx";
 		header('Content-disposition: attachment; filename="'.XLSXWriter::sanitize_filename($filename).'"');
 		header('Content-Type: application/vnd.openxmlformats-officedocument.spreadsheetml.sheet');
@@ -35,4 +38,5 @@
 		// write file
 		$writer->writeToStdOut();
 		unset($writer);
+exit(0);
 ?>

--- a/xlsxwriter.class.php
+++ b/xlsxwriter.class.php
@@ -1,5 +1,5 @@
 <?php
-/*	Updated for column width by Pathfinder Associates, Inc. 4/2/2017
+/*	Updated for column width by Pathfinder Associates, Inc. 4/10/2017
  * @license MIT License
  * */
 
@@ -10,7 +10,7 @@ class XLSXWriter
 	//------------------------------------------------------------------
 	//http://office.microsoft.com/en-us/excel-help/excel-specifications-and-limits-HP010073849.aspx
 	// added version property so apps can check version
-	const version = "0.40";
+	const version = "0.41";
 	const EXCEL_2007_MAX_ROW=1048576;
 	const EXCEL_2007_MAX_COL=16384;
 	//------------------------------------------------------------------
@@ -183,7 +183,7 @@ class XLSXWriter
 			// if no specific colwidths for this sheet then default
 			$c = '<col max="1025" min="1" width="';
 			$c .= $this->colwidth; 
-			$c .= '"/>"';
+			$c .= '"/>';
 		}
 		return $c;
 	}


### PR DESCRIPTION
(Note: first time GitHub user and fairly new to PHP so let me know if this is the wrong way to handle this!)

I love the PHP_XLXSWriter class and it does everything I want except I need some custom column widths to make the resulting sheets more readable to my users.

I added two functions -- 

- setColWidth()  to change default width for all column in a sheet when initialized from the global default of 11.5 to some other value 

- setColWidths() to pass a sheet name and an array of column widths for that sheet.

These values are used in building the XML for the <col /col> when a sheet is initialized.

I included an example-colwidths.php to demonstrate the functionality and updated the ReadMe file.
