### PR TITLE
Added support for elapsed times longer than 99 hours, and shorter than 10

### DIFF
--- a/xlsxwriter.class.php
+++ b/xlsxwriter.class.php
@@ -715,7 +715,7 @@ class XLSXWriter
 		{
 			list($junk,$year,$month,$day) = $matches;
 		}
-		if (preg_match("/(\d{2}):(\d{2}):(\d{2})/", $date_time, $matches))
+		if (preg_match("/(\d+):(\d{2}):(\d{2})/", $date_time, $matches))
 		{
 			list($junk,$hour,$min,$sec) = $matches;
 			$seconds = ( $hour * 60 * 60 + $min * 60 + $sec ) / ( 24 * 60 * 60 );


### PR DESCRIPTION
If the date_time column is used to store elapsed times, 99 hours is definitely not enough for project tracking.

This change is backwards compatible, while also support times without a leading zero.