### PR TITLE
Date/time format detection now accepts lowercase letters

### DIFF
--- a/xlsxwriter.class.php
+++ b/xlsxwriter.class.php
@@ -705,11 +705,11 @@ class XLSXWriter
 		if ($num_format=='GENERAL') return 'n_auto';
 		if ($num_format=='@') return 'n_string';
 		if ($num_format=='0') return 'n_numeric';
-		if (preg_match("/[H]{1,2}:[M]{1,2}/", $num_format)) return 'n_datetime';
-		if (preg_match("/[M]{1,2}:[S]{1,2}/", $num_format)) return 'n_datetime';
-		if (preg_match("/[YY]{2,4}/", $num_format)) return 'n_date';
-		if (preg_match("/[D]{1,2}/", $num_format)) return 'n_date';
-		if (preg_match("/[M]{1,2}/", $num_format)) return 'n_date';
+		if (preg_match("/[H]{1,2}:[M]{1,2}/i", $num_format)) return 'n_datetime';
+		if (preg_match("/[M]{1,2}:[S]{1,2}/i", $num_format)) return 'n_datetime';
+		if (preg_match("/[Y]{2,4}/i", $num_format)) return 'n_date';
+		if (preg_match("/[D]{1,2}/i", $num_format)) return 'n_date';
+		if (preg_match("/[M]{1,2}/i", $num_format)) return 'n_date';
 		if (preg_match("/$/", $num_format)) return 'n_numeric';
 		if (preg_match("/%/", $num_format)) return 'n_numeric';
 		if (preg_match("/0/", $num_format)) return 'n_numeric';


### PR DESCRIPTION
Excel date and time formats can be specified using lowercase letters. Updated the function `determineNumberFormatType` to accept lowercase letters.