### PR TITLE
Column widths compatible with Excel for Mac

### DIFF
--- a/xlsxwriter.class.php
+++ b/xlsxwriter.class.php
@@ -148,11 +148,11 @@ class XLSXWriter
 		$i=0;
 		if (!empty($col_widths)) {
 			foreach($col_widths as $column_width) {
-				$sheet->file_writer->write(  '<col collapsed="false" hidden="false" max="'.($i+1).'" min="'.($i+1).'" style="0" width="'.floatval($column_width).'"/>');
+				$sheet->file_writer->write(  '<col collapsed="false" hidden="false" max="'.($i+1).'" min="'.($i+1).'" style="0" customWidth="true" width="'.floatval($column_width).'"/>');
 				$i++;
 			}
 		}
-		$sheet->file_writer->write(  '<col collapsed="false" hidden="false" max="1024" min="'.($i+1).'" style="0" width="11.5"/>');
+		$sheet->file_writer->write(  '<col collapsed="false" hidden="false" max="1024" min="'.($i+1).'" style="0" customWidth="false" width="11.5"/>');
 		$sheet->file_writer->write(  '</cols>');
 		$sheet->file_writer->write(  '<sheetData>');
 	}


### PR DESCRIPTION
Add missing XML attribute `customWidth="true"` so Excel for Mac can display custom column widths.