### PR TITLE
Remove '=' sign for formula as it is already wrapped in <f>

### DIFF
--- a/xlsxwriter.class.php
+++ b/xlsxwriter.class.php
@@ -363,7 +363,7 @@ class XLSXWriter
 		if (!is_scalar($value) || $value==='') { //objects, array, empty
 			$file->write('<c r="'.$cell_name.'" s="'.$cell_style_idx.'"/>');
 		} elseif (is_string($value) && $value{0}=='='){
-			$file->write('<c r="'.$cell_name.'" s="'.$cell_style_idx.'" t="s"><f>'.self::xmlspecialchars($value).'</f></c>');
+			$file->write('<c r="'.$cell_name.'" s="'.$cell_style_idx.'" t="s"><f>'.self::xmlspecialchars(str_replace('=', '', $value)).'</f></c>');
 		} elseif ($num_format_type=='n_date') {
 			$file->write('<c r="'.$cell_name.'" s="'.$cell_style_idx.'" t="n"><v>'.intval(self::convert_date_time($value)).'</v></c>');
 		} elseif ($num_format_type=='n_datetime') {


### PR DESCRIPTION
All formulas I added to any cell kept coming up with double equals signs which caused an error when opened in a program like google sheets.

It seems like `<f>` already identifies the cell as a formula and translates to a '=' so the extra equals sign isn't needed. 

This pull request removes the equals sign after the row is identified as a formula so only `<f>` is used instead of `<f>=...`