### PR TITLE
Ignore quoted format strings when determining number format

### DIFF
--- a/xlsxwriter.class.php
+++ b/xlsxwriter.class.php
@@ -773,14 +773,14 @@ class XLSXWriter
 		if ($num_format=='GENERAL') return 'n_auto';
 		if ($num_format=='@') return 'n_string';
 		if ($num_format=='0') return 'n_numeric';
-		if (preg_match("/[H]{1,2}:[M]{1,2}/i", $num_format)) return 'n_datetime';
-		if (preg_match("/[M]{1,2}:[S]{1,2}/i", $num_format)) return 'n_datetime';
-		if (preg_match("/[Y]{2,4}/i", $num_format)) return 'n_date';
-		if (preg_match("/[D]{1,2}/i", $num_format)) return 'n_date';
-		if (preg_match("/[M]{1,2}/i", $num_format)) return 'n_date';
-		if (preg_match("/$/", $num_format)) return 'n_numeric';
-		if (preg_match("/%/", $num_format)) return 'n_numeric';
-		if (preg_match("/0/", $num_format)) return 'n_numeric';
+		if (preg_match('/[H]{1,2}:[M]{1,2}(?![^"]*+")/i', $num_format)) return 'n_datetime';
+		if (preg_match('/[M]{1,2}:[S]{1,2}(?![^"]*+")/i', $num_format)) return 'n_datetime';
+		if (preg_match('/[Y]{2,4}(?![^"]*+")/i', $num_format)) return 'n_date';
+		if (preg_match('/[D]{1,2}(?![^"]*+")/i', $num_format)) return 'n_date';
+		if (preg_match('/[M]{1,2}(?![^"]*+")/i', $num_format)) return 'n_date';
+		if (preg_match('/$(?![^"]*+")/', $num_format)) return 'n_numeric';
+		if (preg_match('/%(?![^"]*+")/', $num_format)) return 'n_numeric';
+		if (preg_match('/0(?![^"]*+")/', $num_format)) return 'n_numeric';
 		return 'n_auto';
 	}
 	//------------------------------------------------------------------


### PR DESCRIPTION
When determining the number format, do not consider characters that have been escaped. For example, a number format like this: 
#,##0" W/m2"
Should not be interpreted as an "n_date" column just because it contains the character "m".
This implements a simple solution, where if the format string contains an double-quote after the search string, it does not match. Check the regex for the "M" (month) regex [here](http://www.rubular.com/r/gtpT2E1sX7).
A more robust regex is described [here](https://stackoverflow.com/questions/1191397/regex-to-match-values-not-surrounded-by-another-char)
A better solution would be to not use regex here at all but something more along the lines of how numberFormatStandardized() reads through the string.