### PR TITLE
Allow the start of the auto filter range to be defined

### DIFF
--- a/examples/ex09-autofilter.php
+++ b/examples/ex09-autofilter.php
@@ -5,7 +5,19 @@ include_once("xlsxwriter.class.php");
 $chars = 'abcdefgh';
 
 $writer = new XLSXWriter();
-$writer->writeSheetHeader('Sheet1', array('col-string'=>'string','col-numbers'=>'integer','col-timestamps'=>'datetime'), ['auto_filter'=>true, 'widths'=>[15,15,30]] );
+
+/**
+ * auto_filter may also be set to numbers greater than 1 to offset the
+ * start row for the auto filter data range. This will have the effect
+ * of changing the start row for the data to be filtered and there-by
+ * the row the dropdown filters show on to the row number specified
+ * in this option.
+ */
+$writer->writeSheetHeader(
+    'Sheet1',
+    ['col-string'=>'string', 'col-numbers'=>'integer', 'col-timestamps'=>'datetime'],
+    ['auto_filter'=>1, 'widths'=>[15, 15, 30]]
+);
 for($i=0; $i<1000; $i++)
 {
     $writer->writeSheetRow('Sheet1', array(

--- a/xlsxwriter.class.php
+++ b/xlsxwriter.class.php
@@ -308,7 +308,7 @@ class XLSXWriter
 		$max_cell = self::xlsCell($sheet->row_count - 1, count($sheet->columns) - 1);
 
 		if ($sheet->auto_filter) {
-			$sheet->file_writer->write(    '<autoFilter ref="A1:' . $max_cell . '"/>');			
+			$sheet->file_writer->write(    '<autoFilter ref="A' . (is_int($sheet->auto_filter) ? $sheet->auto_filter : 1) . ':' . $max_cell . '"/>');
 		}
 
 		$sheet->file_writer->write(    '<printOptions headings="false" gridLines="false" gridLinesSet="true" horizontalCentered="false" verticalCentered="false"/>');
@@ -666,7 +666,7 @@ class XLSXWriter
 		foreach($this->sheets as $sheet_name=>$sheet) {
 			if ($sheet->auto_filter) {
 				$sheetname = self::sanitize_sheetname($sheet->sheetname);
-				$workbook_xml.='<definedName name="_xlnm._FilterDatabase" localSheetId="0" hidden="1">\''.self::xmlspecialchars($sheetname).'\'!$A$1:' . self::xlsCell($sheet->row_count - 1, count($sheet->columns) - 1, true) . '</definedName>';
+				$workbook_xml.='<definedName name="_xlnm._FilterDatabase" localSheetId="0" hidden="1">\''.self::xmlspecialchars($sheetname).'\'!$A$' . (is_int($sheet->auto_filter) ? $sheet->auto_filter : 1) . ':' . self::xlsCell($sheet->row_count - 1, count($sheet->columns) - 1, true) . '</definedName>';
 				$i++;	
 			}
 		}


### PR DESCRIPTION
These changes use a numeric value assigned to the auto_filter option as the starting row for the auto filter range. This allows for cases where there may be multiple heading rows (categories and individual column labels) where you want the filtering to start from the second row rather than the first. The current start position is hard coded.

The value passed to auto_filter is currently passed through intval so an existing true option value would be evaluated to 1 meaning backwards compatibility is preserved.