### PR TITLE
Properly checking if timezone is set

### DIFF
--- a/xlsxwriter.class.php
+++ b/xlsxwriter.class.php
@@ -27,7 +27,7 @@ class XLSXWriter
 
 	public function __construct()
 	{
-		if(!ini_get('date.timezone'))
+		if(!date_default_timezone_get())
 		{
 			//using date functions can kick out warning if this isn't set
 			date_default_timezone_set('UTC');


### PR DESCRIPTION
Current code will "change" properly set timezone using `date_default_timezone_set('Europe/Warsaw');` which is date.timezone equivalent in code (you can either set timezone in code or php.ini).

date.timezone is a fallback while using: `date_default_timezone_get()`:http://php.net/manual/pl/function.date-default-timezone-get.php