### PR TITLE
FIX: Fixes issue #203 (corrupted file).

### DIFF
--- a/xlsxwriter.class.php
+++ b/xlsxwriter.class.php
@@ -747,7 +747,7 @@ class XLSXWriter
 		static $badchars  = '\\/?*:[]';
 		static $goodchars = '        ';
 		$sheetname = strtr($sheetname, $badchars, $goodchars);
-		$sheetname = substr($sheetname, 0, 31);
+		$sheetname = mb_substr($sheetname, 0, 31);
 		$sheetname = trim(trim(trim($sheetname),"'"));//trim before and after trimming single quotes
 		return !empty($sheetname) ? $sheetname : 'Sheet'.((rand()%900)+100);
 	}


### PR DESCRIPTION
The source of the corruption was a not multibyte-safe sanitization of
the sheet name. So in case a sheet name contains non Latin characters,
it could lead to corrupted sheet name, which causes the corrupted file
warning from Excel.