### PR TITLE
Avoiding error when using writeToStdOut/String with an empty document.

### DIFF
--- a/xlsxwriter.class.php
+++ b/xlsxwriter.class.php
@@ -66,20 +66,24 @@ class XLSXWriter
 	public function writeToStdOut()
 	{
 		$temp_file = $this->tempFilename();
-		self::writeToFile($temp_file);
+		self::writeToFile($temp_file, true);
 		readfile($temp_file);
 	}
 
 	public function writeToString()
 	{
 		$temp_file = $this->tempFilename();
-		self::writeToFile($temp_file);
+		self::writeToFile($temp_file, true);
 		$string = file_get_contents($temp_file);
 		return $string;
 	}
 
-	public function writeToFile($filename)
+	public function writeToFile($filename, $forceCreateFile=false)
 	{
+        // Create an empty sheet on forceCreateFile
+	    if (empty($this->sheets) and $forceCreateFile)
+	        $this->writeSheetRow('Sheet1', array(''));
+
 		foreach($this->sheets as $sheet_name => $sheet) {
 			self::finalizeSheet($sheet_name);//making sure all footers have been written
 		}


### PR DESCRIPTION
As writeToFile doesn’t create a temp file on empty document, resulting in an error, we assure to have at least one cell written for writeToStdOut and writeToString methods.