### PR TITLE
Implement explicitly setting column types

### DIFF
--- a/examples/ex12-column-types.php
+++ b/examples/ex12-column-types.php
@@ -1,0 +1,21 @@
+<?php
+set_include_path(get_include_path() . PATH_SEPARATOR . '..');
+include_once("xlsxwriter.class.php");
+
+$data = [
+    ['Roman', '', '', '42'],
+    ['Jackie', '', '', '43'],
+    ['Steve', '', '', '17'],
+];
+
+$writer = new XLSXWriter();
+$writer->setSheetColumnTypes('Sheet1', ['string', '@', '@', '@']);
+$writer->writeSheetRow('Sheet1', ['Name', 'Not in use', 'Not in use', 'Value']);
+
+foreach($data as $row)
+{
+    $writer->writeSheetRow('Sheet1', $row);
+}
+
+$writer->writeToFile('column-types.xlsx');
+

--- a/xlsxwriter.class.php
+++ b/xlsxwriter.class.php
@@ -211,8 +211,9 @@ class XLSXWriter
      * @param string $sheetName
      * @param array $types
      */
-	public function setSheetHeaderTypes(string $sheetName, array $types): void
+	public function setSheetColumnTypes(string $sheetName, array $types): void
     {
+        $this->initializeSheet($sheetName);
         $sheet = &$this->sheets[$sheetName];
         $sheet->columns = $this->initializeColumnTypes($types);
     }

--- a/xlsxwriter.class.php
+++ b/xlsxwriter.class.php
@@ -207,6 +207,16 @@ class XLSXWriter
 		return $column_types;
 	}
 
+    /**
+     * @param string $sheetName
+     * @param array $types
+     */
+	public function setSheetHeaderTypes(string $sheetName, array $types): void
+    {
+        $sheet = &$this->sheets[$sheetName];
+        $sheet->columns = $this->initializeColumnTypes($types);
+    }
+
 	public function writeSheetHeader($sheet_name, array $header_types, $col_options = null)
 	{
 		if (empty($sheet_name) || empty($header_types) || !empty($this->sheets[$sheet_name]))


### PR DESCRIPTION
I've faced with needs to explicitly set column types, so I've decided to separate set column types method and set header method. Because it was impossible, for example, set types for columns with the same names. See `ex12-column-types.php`.