### PR TITLE
Fix '=' in Google Sheets

### DIFF
--- a/xlsxwriter.class.php
+++ b/xlsxwriter.class.php
@@ -369,7 +369,7 @@ class XLSXWriter
 		if (!is_scalar($value) || $value==='') { //objects, array, empty
 			$file->write('<c r="'.$cell_name.'" s="'.$cell_style_idx.'"/>');
 		} elseif (is_string($value) && $value[0]=='='){
-			$file->write('<c r="'.$cell_name.'" s="'.$cell_style_idx.'" t="s"><f>'.self::xmlspecialchars($value).'</f></c>');
+			$file->write('<c r="'.$cell_name.'" s="'.$cell_style_idx.'" t="s"><f>'.self::xmlspecialchars(ltrim($value, '=')).'</f></c>');
 		} elseif ($num_format_type=='n_date') {
 			$file->write('<c r="'.$cell_name.'" s="'.$cell_style_idx.'" t="n"><v>'.intval(self::convert_date_time($value)).'</v></c>');
 		} elseif ($num_format_type=='n_datetime') {


### PR DESCRIPTION
Hello,

When an excel file is opened on Google Sheets, we can see a double equal symbol for cells that contain a formula.

This error is known #213 and having no news of this PR #208, I created a new PR.