### PR TITLE
Add missing property, fix call to htmlspecialchars by ensuring the pa…

### DIFF
--- a/xlsxwriter.class.php
+++ b/xlsxwriter.class.php
@@ -19,6 +19,7 @@ class XLSXWriter
 	protected $company;
 	protected $description;
 	protected $keywords = array();
+	protected $tempdir;
 	
 	protected $current_sheet;
 	protected $sheets = array();
@@ -764,7 +765,7 @@ class XLSXWriter
 		//note, badchars does not include \t\n\r (\x09\x0a\x0d)
 		static $badchars = "\x00\x01\x02\x03\x04\x05\x06\x07\x08\x0b\x0c\x0e\x0f\x10\x11\x12\x13\x14\x15\x16\x17\x18\x19\x1a\x1b\x1c\x1d\x1e\x1f\x7f";
 		static $goodchars = "                              ";
-		return strtr(htmlspecialchars($val, ENT_QUOTES | ENT_XML1), $badchars, $goodchars);//strtr appears to be faster than str_replace
+		return strtr(htmlspecialchars((string)$val, ENT_QUOTES | ENT_XML1), $badchars, $goodchars);//strtr appears to be faster than str_replace
 	}
 	//------------------------------------------------------------------
 	public static function array_first_key(array $arr)


### PR DESCRIPTION
Fix two deprecated warnings:
```
PHP Deprecated:  Creation of dynamic property XLSXWriter::$tempdir is deprecated in vendor/mk-j/php_xlsxwriter/xlsxwriter.class.php on line 44
```
```
PHP Deprecated:  htmlspecialchars(): Passing null to parameter #1 ($string) of type string is deprecated in vendor/mk-j/php_xlsxwriter/xlsxwriter.class.php on line 760
```