### PR TITLE
Update xlsxwriter.class.php

### DIFF
--- a/xlsxwriter.class.php
+++ b/xlsxwriter.class.php
@@ -763,6 +763,10 @@ class XLSXWriter
 	//------------------------------------------------------------------
 	public static function xmlspecialchars($val)
 	{
+		if ($val === null) {
+            return '';
+        }
+		
 		//note, badchars does not include \t\n\r (\x09\x0a\x0d)
 		static $badchars = "\x00\x01\x02\x03\x04\x05\x06\x07\x08\x0b\x0c\x0e\x0f\x10\x11\x12\x13\x14\x15\x16\x17\x18\x19\x1a\x1b\x1c\x1d\x1e\x1f\x7f";
 		static $goodchars = "                              ";


### PR DESCRIPTION
Avoid PHP deprecation warning Deprecated: htmlspecialchars(): Passing null to parameter #1 ($string) of type string is deprecated in xlsxwriter.class.php on line 767